### PR TITLE
Do not remove empty fields in response

### DIFF
--- a/rt/rt.py
+++ b/rt/rt.py
@@ -337,7 +337,7 @@ class Rt:
                 raise UnexpectedMessageFormat(
                         "Missing line starting with `{}:`.".format(key),
                 )
-        return {key: '\n'.join(lines) for key, lines in fields.items() if lines}
+        return {key: '\n'.join(lines) if lines else [] for key, lines in fields.items()}
 
     @classmethod
     def __parse_response_numlist(cls, msg: typing.Iterable[str],


### PR DESCRIPTION
This makes get_ticket() return fields like
'Cc' or 'AdminCc' as empty arrays when there
are no people on them (previously they were
missing from the response).

Fixes #70