### PR TITLE
Fix sorting when using search() method

### DIFF
--- a/rt/rest2.py
+++ b/rt/rest2.py
@@ -514,7 +514,11 @@ class Rt:
             query.append(raw_query)
         get_params['query'] = ' AND '.join('(' + part + ')' for part in query)
         if order:
-            get_params['orderby'] = order
+            if order.startswith("-"):
+                get_params['orderby'] = order[1:]
+                get_params['order'] = "DESC"
+            else:
+                get_params['orderby'] = order
 
         if query_format == 'l':
             get_params['fields'] = 'Owner,Status,Created,Subject,Queue,CustomFields,Requestor,Cc,AdminCc,Started,Created,TimeEstimated,Due,Type,InitialPriority,Priority,TimeLeft,LastUpdated'


### PR DESCRIPTION
the `order`  param of the query wasn't sent to RT API (only `orderby`), meaning that sorting worked only with ASC sort (which is set by default)
Fixed that.
linked to [issue 89](https://github.com/python-rt/python-rt/issues/89)