### PR TITLE
Update REST V1 ticket_create documentation to match API docs

### DIFF
--- a/rt/rest1.py
+++ b/rt/rest1.py
@@ -670,7 +670,7 @@ class Rt:
             content=id: ticket/new
             Queue: General
             Owner: Nobody
-            Requestors: somebody@example.com
+            Requestor: somebody@example.com
             Subject: Ticket created through REST API
             Text: Lorem Ipsum
 
@@ -694,7 +694,7 @@ class Rt:
                         List of 2/3 tuples: (filename, file-like object, [content type])
         :keyword kwargs: Other arguments possible to set:
 
-                         Requestors, Subject, Cc, AdminCc, Owner, Status,
+                         Requestor, Subject, Cc, AdminCc, Owner, Status,
                          Priority, InitialPriority, FinalPriority,
                          TimeEstimated, Starts, Due, Text,... (according to RT
                          fields)

--- a/rt/rest2.py
+++ b/rt/rest2.py
@@ -574,7 +574,7 @@ class Rt:
         :param attachments: Optional list of :py:class:`~rt.rest2.Attachment` objects
         :param kwargs: Other arguments possible to set:
 
-                         Requestors, Cc, AdminCc, Owner, Status,
+                         Requestor, Cc, AdminCc, Owner, Status,
                          Priority, InitialPriority, FinalPriority,
                          TimeEstimated, Starts, Due
 


### PR DESCRIPTION
The REST v1 client docs specify `Requestors` as a param for `ticket_create`. According to the [REST API docs](https://rt-wiki.bestpractical.com/wiki/REST#Ticket_Create) the correct param to pass is actually `Requestor`.

We found that when passing `Requestors` as a param, the ticket is created successfully but no acknowledgment email is sent.