### PR TITLE
result['pages'].replace(result['count'])

### DIFF
--- a/rt/rest2.py
+++ b/rt/rest2.py
@@ -312,8 +312,8 @@ class Rt:
 
             yield from result['items']
 
-            if recurse and result['pages'] > result['page']:
-                for _page in range(2, result['pages'] + 1):
+            if recurse and result['count'] > result['page']:
+                for _page in range(2, result['count'] + 1):
                     yield from self.__paged_request(selector, json_data=json_data, page=_page,
                                                     per_page=result['per_page'], params=params, recurse=False)
 
@@ -1679,8 +1679,8 @@ class AsyncRt:
             for item in result['items']:
                 yield item
 
-            if recurse and result['pages'] > result['page']:
-                for _page in range(2, result['pages'] + 1):
+            if recurse and result['count'] > result['page']:
+                for _page in range(2, result['count'] + 1):
                     async for item in self.__paged_request(selector,
                                                            json_data=json_data,
                                                            page=_page,


### PR DESCRIPTION
*result['pages']* can return None. This will result in the following exception: 

`TypeError: '>' not supported between instances of 'NoneType' and 'int'` in the file [rest2.py](https://github.com/python-rt/python-rt/blob/master/rt/rest2.py#L315C28-L315C43).

As far as I understand the 'pages' attribute is used to check if there are additional pages and as a counter to iterate over those pages. 

Instead of using *result['pages']* I suggest using *result['count']*. 

Here's an example of a data structure where the current code would fail:
```json
{'per_page': 20, 'total': None, 'items': [{'type': 'attachment', 'ContentType': 'image/png', 'Filename': 'image002.png', 'id': 'XXX', '_url': 'XXX/8939679', 'ContentLength': 'XXX'}, {'ContentLength': 'XXX', 'id': 'XXX', '_url': 'XXX', 'Filename': 'XXX', 'type': 'attachment', 'ContentType': 'XXX'}, {'ContentLength': 'XXX', 'id': 'XXX', '_url': 'XXXX', 'Filename': 'XXXX', 'ContentType': 'XXXX', 'type': 'attachment'}], 'pages': None, 'page': 1, 'count': 3}
```

In this case count=3, which is correct. *pages* is however **None**

@sim0nx 