### PR TITLE
implement workaround for undefined pages variable in RT >=5.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.1.4], 2024-02-16
+### Fixes
+- Add a workaround for a breaking change introduced in RT5.0.5 which returns undefined pages variable for non-superusers (see #93 #94).
+
 ## [v3.1.3], 2023-10-10
 ### Fixes
 - Fix an issue where no e-mail was sent on ticket creation due to suggesting to use **Requestors** instead of **Requestor** (https://github.com/python-rt/python-rt/pull/92).


### PR DESCRIPTION
RT 5.0.5 returns a pages=None value for non-superusers, preventing doing pagination for normal users.

c.f. https://github.com/bestpractical/rt/commit/c2d5d72cd5e6cfaed744a3a2defe716ca96d5375#diff-00956f5704676bcdb903e909bfe2ad469d41f62430025b94d4563c14283cb02aR3722

Here we do an endless loop over pages until no more results are returned; until RT fixes this issue upstream.