### PR TITLE
Custom Fields for population in search functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.2.0], 2024-09-06
+## Added
+- Added option for custom list of fields to be populated for search "query_format" param to avoid unnecessary round trips to get fields like Told, Starts, Resolved, etc by returning the required fields during search. (see #97 @nerdfirefighter)
+
 ## [v3.1.4], 2024-02-16
 ### Fixes
 - Add a workaround for a breaking change introduced in RT5.0.5 which returns undefined pages variable for non-superusers (see #93 #94).

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 3.2.0 (2024-09-06)
+----------------------------
+Added
+^^^^^
+- Added option for custom list of fields to be populated for search "query_format" param to avoid unnecessary round trips to get fields like Told, Starts, Resolved, etc by returning the required fields during search. (see #97 @nerdfirefighter)
+
 Version 3.1.4 (2024-02-16)
 ----------------------------
 Fixes

--- a/rt/rest2.py
+++ b/rt/rest2.py
@@ -12,7 +12,7 @@ import json
 import logging
 import re
 import typing
-from typing import Literal, List
+from typing import Literal
 from urllib.parse import urljoin
 
 import httpx
@@ -445,7 +445,7 @@ class Rt:
         queue: typing.Optional[typing.Union[str, object]] = None,
         order: typing.Optional[str] = None,
         raw_query: typing.Optional[str] = None,
-        query_format: typing.Union[str, list[str]] = 'l',
+        query_format: typing.Union[str, typing.List[str]] = 'l',
         **kwargs: typing.Any,
     ) -> typing.Iterator[dict]:
         r"""Search arbitrary needles in given fields and queue.
@@ -1940,7 +1940,7 @@ class AsyncRt:
         queue: typing.Optional[typing.Union[str, object]] = None,
         order: typing.Optional[str] = None,
         raw_query: typing.Optional[str] = None,
-        query_format: typing.Union[str, list[str]] = 'l',
+        query_format: typing.Union[str, typing.List[str]] = 'l',
         **kwargs: typing.Any,
     ) -> collections.abc.AsyncIterator:
         r"""Search arbitrary needles in given fields and queue.

--- a/rt/rest2.py
+++ b/rt/rest2.py
@@ -445,7 +445,7 @@ class Rt:
         queue: typing.Optional[typing.Union[str, object]] = None,
         order: typing.Optional[str] = None,
         raw_query: typing.Optional[str] = None,
-        query_format: str = 'l',
+        query_format: typing.Union[str, list[str]] = 'l',
         **kwargs: typing.Any,
     ) -> typing.Iterator[dict]:
         r"""Search arbitrary needles in given fields and queue.
@@ -472,6 +472,7 @@ class Rt:
                                - i: only *id* fields are populated
                                - s: only *id* and *subject* fields are populated
                                - l: multi-line format, all fields are populated
+                               - [field1, field2]: list of fields to be populated 
         :param kwargs:     Other arguments possible to set if not passing raw_query:
 
                              Requestors, Subject, Cc, AdminCc, Owner, Status,
@@ -536,7 +537,9 @@ class Rt:
             else:
                 get_params['orderby'] = order
 
-        if query_format == 'l':
+        if isinstance(query_format, list):
+            get_params['fields'] = ','.join(query_format)
+        elif query_format == 'l':
             get_params[
                 'fields'
             ] = 'Owner,Status,Created,Subject,Queue,CustomFields,Requestor,Cc,AdminCc,Started,Created,TimeEstimated,Due,Type,InitialPriority,Priority,TimeLeft,LastUpdated'
@@ -1937,7 +1940,7 @@ class AsyncRt:
         queue: typing.Optional[typing.Union[str, object]] = None,
         order: typing.Optional[str] = None,
         raw_query: typing.Optional[str] = None,
-        query_format: str = 'l',
+        query_format: typing.Union[str, list[str]] = 'l',
         **kwargs: typing.Any,
     ) -> collections.abc.AsyncIterator:
         r"""Search arbitrary needles in given fields and queue.
@@ -1964,6 +1967,7 @@ class AsyncRt:
                                - i: only *id* fields are populated
                                - s: only *id* and *subject* fields are populated
                                - l: multi-line format, all fields are populated
+                               - [field1, field2]: list of fields to be populated 
         :param kwargs:     Other arguments possible to set if not passing raw_query:
 
                              Requestors, Subject, Cc, AdminCc, Owner, Status,
@@ -2029,7 +2033,9 @@ class AsyncRt:
             else:
                 get_params['orderby'] = order
 
-        if query_format == 'l':
+        if isinstance(query_format, list):
+            get_params['fields'] = ','.join(query_format)
+        elif query_format == 'l':
             get_params[
                 'fields'
             ] = 'Owner,Status,Created,Subject,Queue,CustomFields,Requestor,Cc,AdminCc,Started,Created,TimeEstimated,Due,Type,InitialPriority,Priority,TimeLeft,LastUpdated'

--- a/rt/rest2.py
+++ b/rt/rest2.py
@@ -472,7 +472,7 @@ class Rt:
                                - i: only *id* fields are populated
                                - s: only *id* and *subject* fields are populated
                                - l: multi-line format, all fields are populated
-                               - [field1, field2]: list of fields to be populated 
+                               - [field1, field2]: list of fields to be populated
         :param kwargs:     Other arguments possible to set if not passing raw_query:
 
                              Requestors, Subject, Cc, AdminCc, Owner, Status,
@@ -1967,7 +1967,7 @@ class AsyncRt:
                                - i: only *id* fields are populated
                                - s: only *id* and *subject* fields are populated
                                - l: multi-line format, all fields are populated
-                               - [field1, field2]: list of fields to be populated 
+                               - [field1, field2]: list of fields to be populated
         :param kwargs:     Other arguments possible to set if not passing raw_query:
 
                              Requestors, Subject, Cc, AdminCc, Owner, Status,

--- a/rt/rest2.py
+++ b/rt/rest2.py
@@ -12,7 +12,7 @@ import json
 import logging
 import re
 import typing
-from typing import Literal
+from typing import Literal, List
 from urllib.parse import urljoin
 
 import httpx

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -75,6 +75,13 @@ def test_ticket_operations(rt_connection: rt.rest2.Rt):
     assert search_result[0]['id'] == str(ticket_id)
     assert search_result[0]['Status'] == 'new'
 
+    # search with query_format field list
+    search_result = list(rt_connection.search(Subject=ticket_subject, query_format=['Status','Subject']))
+    assert len(search_result) == 1
+    assert search_result[0]['Subject'] == str(ticket_subject)
+    assert search_result[0]['Status'] == 'new'
+    assert 'Requestor' not in search_result[0].keys()
+
     # raw search
     search_result = list(rt_connection.search(raw_query=f'Subject="{ticket_subject}"'))
     assert len(search_result) == 1

--- a/tests/test_basic_async.py
+++ b/tests/test_basic_async.py
@@ -78,6 +78,13 @@ async def test_ticket_operations(async_rt_connection: rt.rest2.AsyncRt):
     assert search_result[0]['id'] == str(ticket_id)
     assert search_result[0]['Status'] == 'new'
 
+    # search with query_format field list
+    search_result = [item async for item in async_rt_connection.search(Subject=ticket_subject, query_format=['Status','Subject'])]
+    assert len(search_result) == 1
+    assert search_result[0]['Subject'] == str(ticket_subject)
+    assert search_result[0]['Status'] == 'new'
+    assert 'Requestor' not in search_result[0].keys()
+
     # raw search
     search_result = [item async for item in async_rt_connection.search(raw_query=f'Subject="{ticket_subject}"')]
     assert len(search_result) == 1


### PR DESCRIPTION
Added option for custom list of fields to be populated for search "query_format" param to avoid unnecessary round trips to get fields like Told, Starts, Resolved, etc by returning the required fields during search.