### PR TITLE
Pin httpx to version 0.27.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">= 3.9"
 dependencies = [
   "requests",
-  "httpx",
+  "httpx==0.27.2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Temporary fix to get the project working again. A more permanent fix should include removing the `proxies` parameter in the httpx constructor as outlined in [this issue](https://github.com/python-rt/python-rt/issues/102)